### PR TITLE
docs: cite upstream fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OpenTTDLab
 
-Python framework for running reproducible experiments using OpenTTD
+Python framework for running reproducible experiments using OpenTTD.
+
+Forked from [TrueBrain's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader).
 
 ## Python
 


### PR DESCRIPTION
This adds a quick citation/link to TrueBrain's OpenTTD Savegame Reader. TrueBrain is listed as a contributor, even though they haven't (and probably won't) directly contribute to this project. So it's a "thank you", but also hints at "unaffiliated with".