### PR TITLE
docs: use based on rather than forked

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Python framework for running reproducible experiments using OpenTTD.
 
-Forked from [TrueBrain's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader).
+Based on [TrueBrain's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader).
 
 > Work in progress. This README serves as a rough design spec.
 


### PR DESCRIPTION
I think it's clearer to avoid the very GitHub specific language