### PR TITLE
docs: use Note alert to highlight WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This can be configured/extracted for each experiment in either machine or human 
 
 Based on [TrueBrain's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader).
 
+> [!NOTE]
 > Work in progress. This README serves as a rough design spec.
 
 


### PR DESCRIPTION
This uses GitHub's "alert" syntax for highlighting the fact that the README is more of a spec.

This is to draw attention to it a bit better (and maybe to experiment with the syntax a bit + deliberatly try to be more familiar with it). Not sure exactly which level should be used - but avoiding the stronger levels to already start from the point of avoiding their overuse