### PR TITLE
feat: support Python from 3.6.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Python framework for running reproducible experiments using OpenTTD"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.6.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",


### PR DESCRIPTION
This adds support from 3.6.7. While Python 3.6 is quite old now, want to have as high support as possible to make this as useful as possible so people that can't upgrade for whatever reason can still use this.

3.6.7 is chosen because I know that GitHub actions can run tests on it without too much faff, as in
https://github.com/uktrade/stream-zip/blob/main/.github/workflows/test.yml