### PR TITLE
chore: remove requirements files

### DIFF
--- a/requirements.base
+++ b/requirements.base
@@ -1,3 +1,0 @@
-click
-openttd_helpers
-urwid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-certifi==2021.5.30
-click==8.0.1
-openttd-helpers==1.0.1
-sentry-sdk==1.1.0
-urllib3==1.26.5
-urwid==2.1.2


### PR DESCRIPTION
Removed for s reasons:

- Dependencies on now specified via pyproject.toml
- I think we also don't need the dependencies that they specify