### PR TITLE
ci: test with code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,5 @@ jobs:
           pip install ".[ci]"
       - name: "Run tests"
         run: |
-          pytest
+          pytest --cov
+      - uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,14 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+  "coverage>=6.2",
   "pytest>=7.0.1",
+  "pytest-cov>=3.0.0",
 ]
 ci = [
-  "pytest==7.0.1",
+  "coverage>=6.2",
+  "pytest>=7.0.1",
+  "pytest-cov>=3.0.0",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
A bit trivial for now, but start as we mean to go on...

This does make CI use the latest version of dependencies used for testing. This is because pytest would fail on Python 3.11.0 for some reason. Deeming it not worth finding out why