### PR TITLE
feat!: download OpenTTD to a cache directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.6.7"
-            os: "ubuntu-20.04"
-          - python-version: "3.7.1"
-            os: "ubuntu-20.04"
           - python-version: "3.8.0"
             os: "ubuntu-20.04"
           - python-version: "3.9.0"

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -1,5 +1,70 @@
-def setup_experiment():
-    pass
+import hashlib
+import os.path
+import platform
+
+import httpx
+import yaml
+from platformdirs import user_cache_dir
+
+
+def setup_experiment(
+    base_url='https://cdn.openttd.org/openttd-releases/',
+):
+    def get(url):
+        response = httpx.get(url)
+        response.raise_for_status()
+        return response.content
+
+    def get_yaml(url):
+        return yaml.safe_load(get(url))
+
+    # Find latest OpenTTD
+    latest_version = str(get_yaml(base_url + 'latest.yaml')['latest'][0]['version'])
+    manifest = get_yaml(base_url + latest_version + '/manifest.yaml')
+
+    # Find the name of the file to download for this platform
+    system_machine_to_release_params = {
+        ('Darwin', 'arm64'): ('macos', 'universal', 'dmg'),
+        ('Darwin', 'amd64'): ('macos', 'universal', 'dmg'),
+        ('Linux', 'x86_64'): ('linux-generic', 'amd64', 'tar.xz'),
+    }
+    uname = platform.uname()
+    try:
+        operating_system, architecture, extension = system_machine_to_release_params[(uname.system, uname.machine)]
+    except KeyError:
+        raise Exception("Unable to map platform to OpenTTD release", uname.system, uname.machine)
+
+    files_by_id = {
+        file['id']: file
+        for file in manifest['files']
+    }
+    filename = f"{manifest['base']}{operating_system}-{architecture}.{extension}"
+    try:
+        file_details = files_by_id[filename]
+    except KeyError:
+        raise Exception("Unable to fine platform-specific file in OpenTTD release", filename)
+
+    # Check if the file already exists
+    cache_dir = user_cache_dir(appname='OpenTTDLab', ensure_exists=True)
+    expected_file_location = os.path.join(cache_dir, filename)
+    file_exists = os.path.exists(expected_file_location)
+
+    # Download the file if necessary (avoiding loading it all into memory)
+    if not os.path.exists(expected_file_location):
+        with httpx.stream("GET", base_url + latest_version + '/' + filename) as r:
+            r.raise_for_status()
+            with open(expected_file_location, 'wb') as f:
+                for chunk in r.iter_bytes():
+                    f.write(chunk)
+
+    # Check the file matches the SHA256 in the manifest
+    sha256 = hashlib.sha256()
+    with open(expected_file_location, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            sha256.update(chunk)
+
+    if sha256.hexdigest() != file_details['sha256sum']:
+        raise Exception(f"SHA256 of {expected_file_location} does not match its published value")
 
 
 def save_config():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,16 @@ authors = [
 ]
 description = "Python framework for running reproducible experiments using OpenTTD"
 readme = "README.md"
-requires-python = ">=3.6.7"
+requires-python = ">=3.8.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
+]
+dependencies = [
+    "httpx>=0.26.0",
+    "platformdirs>=4.1.0",
+    "PyYAML>=6.0.1",
 ]
 
 [project.urls]
@@ -24,14 +29,19 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-  "coverage>=6.2",
-  "pytest>=7.0.1",
-  "pytest-cov>=3.0.0",
+  "coverage>=7.4.0",
+  "pytest>=7.4.4",
+  "pytest-cov>=4.1.0",
 ]
 ci = [
-  "coverage>=6.2",
-  "pytest>=7.0.1",
-  "pytest-cov>=3.0.0",
+  # Pinned dev dependencies
+  "coverage==7.4.0",
+  "pytest==7.4.4",
+  "pytest-cov==4.1.0",
+  # Pinned normal dependencies
+  "httpx==0.26.0",
+  "platformdirs==4.1.0",
+  "PyYAML==6.0.1",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
Only trying to support Linux and MacOS, because that's all I have access to at the moment.

These tests don't mock anything, and really do download OpenTTD. Maybe not ideal, but it's the easiest thing for now.

BREAKING CHANGE: This drops support for Python earlier than 3.8. This is because the latest version of platformdirs only support Python 3.8 onwards. Often I think using an earlier version is fine, but because it's involved in saving files to the user's machine, I'm opting to just use the most recent out of paranoia.

This should also mean we can now pin the dev dependencies in CI - they were unpinned to allow different versions to run earlier versions of Python.