### PR TITLE
docs: use python rather than pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenTTDLab is based on [TrueBrain's OpenTTD Savegame Reader](https://github.com/
 ## Installation
 
 ```shell
-pip install OpenTTDLab
+python -m pip install OpenTTDLab
 ```
 
 


### PR DESCRIPTION
This should avoid issues with pip/python are installed in different locations