### PR TITLE
feat: extract the downloaded file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: '${{ matrix.python-version }}'
+      - name: "Install 7z"
+        run: |
+           sudo apt-get install -y p7zip-full
       - name: "Install python dependencies"
         run: |
           pip install ".[ci]"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ OpenTTDLab is based on [TrueBrain's OpenTTD Savegame Reader](https://github.com/
 python -m pip install OpenTTDLab
 ```
 
+OpenTTDLab itself depends on [7-zip](https://www.7-zip.org/), but this is not installed automatically.
+
+To install 7-zip on macOS, first install [Homebrew](https://brew.sh/), and then use Homebrew to install the p7zip package that contains 7-zip.
+
+```shell
+brew install p7zip
+```
+
+On Linux, you can usually install 7-zip from your distribution's package repository. For example, for apt-based distributions:
+
+```shell
+sudo apt update
+sudo apt install -y p7zip-full
+```
+
+or for dnf-based distrubtions
+
+```shell
+sudo dnf install p7zip
+```
+
 
 ## Running an experiment
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -1,6 +1,7 @@
 import hashlib
 import os.path
 import platform
+import subprocess
 
 import httpx
 import yaml
@@ -63,8 +64,12 @@ def setup_experiment(
         for chunk in iter(lambda: f.read(65536), b''):
             sha256.update(chunk)
 
-    if sha256.hexdigest() != file_details['sha256sum']:
+    digest = sha256.hexdigest()
+    if digest != file_details['sha256sum']:
         raise Exception(f"SHA256 of {expected_file_location} does not match its published value")
+
+    # Extract the file
+    subprocess.check_output(['7z', 'x', '-y', f'-o{expected_file_location}-{digest}', expected_file_location])
 
 
 def save_config():


### PR DESCRIPTION
This extracts the OpenTTD binary (+ any assocaited files) from the downloaded archive. The 7-zip binary is used for this. While a bit awkward, it does extract dmg files on macOS, and without any sort of mounting of it.