### PR TITLE
docs: use get_config consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ config = load_config('my-config.yml')
 # allow_platform_difference=True will allow experiments from a platform other than the one
 # the original experiments were performed on. Otherwise, setup_experiment may error because
 # the exact same OpenTTD will not be able to be run on this platform
-run_experiment, get_experimental_config = setup_experiment(config=config, allow_platform_difference=True)
+run_experiment, get_config = setup_experiment(config=config, allow_platform_difference=True)
 
 # Run the experiment and get results
 results = run_experiment()


### PR DESCRIPTION
In one place it's get_config, and in another get_experimental config. This change makes it consistent.