### PR TITLE
docs: add image alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <p align="center">
-  <img width="256" height="254" src="./docs/assets/openttdlab-logo.svg">
+  <img alt="OpenTTDLab logo" width="256" height="254" src="./docs/assets/openttdlab-logo.svg">
 </p>
 
 <p align="center"><strong>OpenTTDLab</strong> - <em>Run reproducible experiments on OpenTTD</em></p>
 
 <p align="center">
-    <a href="https://pypi.org/project/OpenTTDLab/"><img src="https://img.shields.io/pypi/v/OpenTTDLab?label=PyPI%20package"></a>
-    <a href="https://github.com/michalc/OpenTTDLab/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/michalc/OpenTTDLab/test.yml?label=Test%20suite"></a>
-    <a href="https://app.codecov.io/gh/michalc/OpenTTDLab"><img src="https://img.shields.io/codecov/c/github/michalc/OpenTTDLab?label=Code%20coverage"></a>
+    <a href="https://pypi.org/project/OpenTTDLab/"><img alt="PyPI package" src="https://img.shields.io/pypi/v/OpenTTDLab?label=PyPI%20package"></a>
+    <a href="https://github.com/michalc/OpenTTDLab/actions/workflows/test.yml"><img alt="Test suite" src="https://img.shields.io/github/actions/workflow/status/michalc/OpenTTDLab/test.yml?label=Test%20suite"></a>
+    <a href="https://app.codecov.io/gh/michalc/OpenTTDLab"><img alt="Code coverage" src="https://img.shields.io/codecov/c/github/michalc/OpenTTDLab?label=Code%20coverage"></a>
 </p>
 
 ---


### PR DESCRIPTION
A bit of brief testing in VoiceOver describes each of these as "unlabelled image", even though the internal SVG has what I thought was the right attributes to be read. Putting alts back onto the images so hopefully they are just a touch more accessible.