### PR TITLE
docs: use raw url for logo rather than relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="OpenTTDLab logo" width="256" height="254" src="./docs/assets/openttdlab-logo.svg">
+  <img alt="OpenTTDLab logo" width="256" height="254" src="https://raw.githubusercontent.com/michalc/OpenTTDLab/main/docs/assets/openttdlab-logo.svg">
 </p>
 
 <p align="center"><strong>OpenTTDLab</strong> - <em>Run reproducible experiments using OpenTTD</em></p>


### PR DESCRIPTION
This is to try to make the logo show up when published to PyPI - so far it doesn't.