### PR TITLE
fix: deploying to PyPI

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: 3.11
 
       - name: Update version from current git tag
-        run: >-
+        run: |
           sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" pyproject.toml
           sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" openttdlab.py
 


### PR DESCRIPTION
This hopefully fixes how the git tag is replaced in files - it's erroring how because I think it's assuming all the lines in the run block are a single command.