### PR TITLE
docs: fix typo/copy-paste error in notice

### DIFF
--- a/openttdlab.py
+++ b/openttdlab.py
@@ -3,7 +3,7 @@
 # Copyright © Michal Charemza: additions and changes to run OpenTTD to generate savegames, and to process parsed savegames further
 # OpenTTDLab is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
 # OpenTTDLab is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+# See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTDLab. If not, see <http://www.gnu.org/licenses/>.
 
 import hashlib
 import os


### PR DESCRIPTION
This changes OpenTTD -> OpenTTDLab, because this is OpenTTDLab, not OpenTTD.