### PR TITLE
docs: use the real name of savegame-reader's author

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenTTDLab is a Python framework for running reproducible experiments using Open
 
 This can be configured/extracted for each experiment in either machine or human readable forms, for use in code or publishing respectively.
 
-OpenTTDLab is based on [TrueBrain's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader), but it is not affiliated with OpenTTD.
+OpenTTDLab is based on [Patric Stout's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader), but it is not affiliated with OpenTTD.
 
 > [!NOTE]
 > Work in progress. This README serves as a rough design spec.
@@ -84,7 +84,7 @@ print(results)
 
 OpenTTDLab is licensed under the [GNU General Public License version 2.0](./LICENSE).
 
-OpenTTDLab is based on [TrueBrain's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader), also licensed under the GNU General Public License version 2.0.
+OpenTTDLab is based on [Patric Stout's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader), also licensed under the GNU General Public License version 2.0.
 
 The [OpenTTDLab logo](./docs/assets/openttdlab-logo.svg) is a modified version of the [OpenTTD logo](https://commons.wikimedia.org/wiki/File:Openttdlogo.svg). The OpenTTD logo is licensed under the GNU General Public License version 2.0.
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -1,5 +1,5 @@
 # This file is part of OpenTTDLab.
-# Copyright © TrueBrain: initial implementation of OpenTTD savegame parsing and converting to link graph
+# Copyright © Patric Stout: initial implementation of OpenTTD savegame parsing and converting to link graph
 # Copyright © Michal Charemza: additions and changes to run OpenTTD to generate savegames, and to process parsed savegames further
 # OpenTTDLab is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
 # OpenTTDLab is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
Suspect it's more appropriate than the GitHub ID