### PR TITLE
docs: make the original author of the logo clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ OpenTTDLab is licensed under the [GNU General Public License version 2.0](./LICE
 
 OpenTTDLab is based on [Patric Stout's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader), also licensed under the GNU General Public License version 2.0.
 
-The [OpenTTDLab logo](./docs/assets/openttdlab-logo.svg) is a modified version of the [OpenTTD logo](https://commons.wikimedia.org/wiki/File:Openttdlogo.svg). The OpenTTD logo is licensed under the GNU General Public License version 2.0.
+The [OpenTTDLab logo](./docs/assets/openttdlab-logo.svg) is a modified version of the [OpenTTD logo](https://commons.wikimedia.org/wiki/File:Openttdlogo.svg), authored by the [OpenTTD team](https://github.com/OpenTTD/OpenTTD/blob/master/CREDITS.md). The OpenTTD logo is licensed under the GNU General Public License version 2.0.
 
 The [.gitignore](./.gitignore) file is based on [GitHub's Python .gitignore file](https://github.com/github/gitignore/blob/main/Python.gitignore). This was originally supplied under CC0 1.0 Universal. However, as part of OpenTTDLab it is licensed under GNU General Public License version 2.0.
 


### PR DESCRIPTION
Don't think it's required to do this in the README (it is mentioned in the file itself), but I think it's nice to have them listed.