### PR TITLE
fix: more deterministic saving

### DIFF
--- a/openttdlab.py
+++ b/openttdlab.py
@@ -182,6 +182,7 @@ def run_experiment(
             [gui]
             autosave = monthly
             keep_all_autosave = true
+            threaded_saves = false
             [difficulty]
             max_no_competitors = 1
         ''' + ai_players_config)

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -9,7 +9,7 @@ def test_run_experiment():
         ),
     )
 
-    assert len(results) == 51
+    assert len(results) == 59
     assert results[0]['PLYR']['0']['name'] == 'trAIns AI'
 
 


### PR DESCRIPTION
The tests seem to be slightly flakey on the number of saved files. Hopefully disabling threaded saves addresses this.