### PR TITLE
docs: remove detail about every file being GPL v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ print(results)
 
 ### TL;DR
 
-OpenTTDLab is licensed under the [GNU General Public License version 2.0](./LICENSE). This covers every file in this repository.
+OpenTTDLab is licensed under the [GNU General Public License version 2.0](./LICENSE).
 
 ### In more detail
 


### PR DESCRIPTION
This is because technically, the text of the GPL v2 is _not_ released under GPL v2. Could add that detail in, but suspect it's not helpful. No-one probably cares and it's clear enough to state that OpenTTDLab is GPL v2.