### PR TITLE
feat: return a (so far null) metadata for cpu and memory info

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The core function of OpenTTD is the `run_experiment` function.
 from openttdlab import run_experiment, remote_file, save_config
 
 # Run the experiment for a range of random seeds
-results, config = run_experiment(
+results, metadata, config = run_experiment(
     days=365 * 4 + 1,
     seeds=range(0, 10),
     ais=(
@@ -55,10 +55,13 @@ results, config = run_experiment(
     ),
 )
 
-# Print the results...
+# Print the results: in-game values that should be exactly reproducible...
 print(results)
 
-# ... and config
+# ... and metadata: such as number of processes, wallclock time and total CPU time
+print(metadata)
+
+# ... and config: to reproduce the results (but not metadata) exactly next time
 print(config)
 
 # ... which can be saved to a file and then shared (or archived)
@@ -96,7 +99,7 @@ from openttdlab import run_experiment, load_config
 config = load_config('my-config-a5e95018.yml')
 
 # ... and use it to run the same experiment
-results, config = run_experiment(config=config)
+results, metadata, config = run_experiment(config=config)
 
 print(results)
 ```

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -232,7 +232,7 @@ def run_experiment(
             savegame_row
             for i, seed in enumerate(seeds)
             for savegame_row in run(experiment_dir, i, seed)
-        ], None
+        ], None, None
 
 
 def local_file(filename):

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -5,7 +5,7 @@ from openttdlab import parse_savegame, run_experiment, local_file, remote_file, 
 
 
 def test_run_experiment_local():
-    results, config = run_experiment(
+    results, metadata, config = run_experiment(
         days=365 * 5 + 1,
         seeds=range(2, 4),
         ais=(
@@ -31,7 +31,7 @@ def test_run_experiment_local():
 
 
 def test_run_experiment_remote():
-    results, config = run_experiment(
+    results, metadata, config = run_experiment(
         days=365 + 1,
         seeds=range(2, 3),
         ais=(


### PR DESCRIPTION
I might change my mind on this, but it might make certain things easier. Say to measure total wallclock time compared with number of processes, or total memory used with number of processes.