### PR TITLE
feat: ability to fetch AIs published on content server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ You do not need to separately download or install OpenTTD (or [OpenGFX](https://
 The core function of OpenTTD is the `run_experiment` function.
 
 ```python
-from openttdlab import run_experiment, remote_file, save_config
+from openttdlab import run_experiment, bananas_file, save_config
 
 # Run the experiment for a range of random seeds
 results, metadata, config = run_experiment(
     days=365 * 4 + 1,
     seeds=range(0, 10),
     ais=(
-        # remote_file: takes a url of a .tar.gz AI file
+        # 3 ways of using Ais
+        # remote_file: takes a url of a .tar.gz AI file, e.g. a GitHub tag
         # local_file: takes a path to a local .tar AI file
-        ('trAIns', remote_file('https://github.com/lhrios/trains/archive/refs/tags/2014_02_14.tar.gz')),
+        # bananas_file: takes the type, name, and id from https://bananas.openttd.org/package/ai
+        ('trAIns', bananas_file('trAIns', '54524149')),
     ),
 )
 

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -3,7 +3,7 @@ from datetime import date
 
 import pytest
 
-from openttdlab import parse_savegame, run_experiment, local_file, remote_file, save_config, load_config
+from openttdlab import parse_savegame, run_experiment, local_file, remote_file, bananas_file, save_config, load_config
 
 
 def test_run_experiment_local():
@@ -38,6 +38,25 @@ def test_run_experiment_remote():
         seeds=range(2, 3),
         ais=(
             ('trAIns', remote_file('https://github.com/lhrios/trains/archive/refs/tags/2014_02_14.tar.gz')),
+        ),
+    )
+
+    assert len(results) == 12
+    assert results[10] == {
+        'seed': 2,
+        'player': 'trAIns AI',
+        'date': date(1950, 12, 1),
+        'loan': 300000,
+        'money': 280615,
+    }
+
+
+def test_run_experiment_bananas():
+    results, metadata, config = run_experiment(
+        days=365 + 1,
+        seeds=range(2, 3),
+        ais=(
+            ('trAIns', bananas_file('trAIns', '54524149')),
         ),
     )
 


### PR DESCRIPTION
There are a few steps involved here. Hopefully it's as simple as it can reasonably be.

The client code does take both a name and unique ID of the AI. Ideally we would just take name so it's clear to the user which AI is being used. However, names are not unique, so to disambiguate them just in case there are multiple AIs with the same name, it also requires the unique ID