### PR TITLE
docs: remove printing of results from experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ results = run_experiment(
         ('trAIns', bananas_file('trAIns', '54524149')),
     ),
 )
-
-# Print the results
-print(results)
 ```
 
 


### PR DESCRIPTION
I suspect it's not helpful to have - it's a very big list of nested dicts