### PR TITLE
feat: start AIs immediately using a startup script

### DIFF
--- a/openttdlab.py
+++ b/openttdlab.py
@@ -196,24 +196,26 @@ def run_experiment(
             Path(experiment_baseset_dir).mkdir(parents=True)
             experiment_ai_dir = os.path.join(run_dir, 'ai')
             Path(experiment_ai_dir).mkdir(parents=True)
+            experiment_script_dir = os.path.join(run_dir, 'scripts')
+            Path(experiment_script_dir).mkdir(parents=True)
 
             # Populate run directory
             shutil.copy(opengfx_binary, experiment_baseset_dir)
             for ai_name, ai_file in ais:
                 shutil.copy(os.path.join(experiment_dir, ai_name + '.tar'), experiment_ai_dir)
             config_file = os.path.join(run_dir, 'openttdlab.cfg')
-            ai_players_config = '[ai_players]\n' + ''.join(
-                f'{ai_name} = start_date=0\n' for ai_name, file in ais
-            )
+
+            with open(os.path.join(experiment_script_dir, 'game_start.scr'), 'w') as f:
+                f.write(''.join(
+                    f'start_ai {ai_name}\n' for ai_name, file in ais
+                ))
             with open(config_file, 'w') as f:
                 f.write(base_openttd_config + textwrap.dedent('''
                     [gui]
                     autosave = monthly
                     keep_all_autosave = true
                     threaded_saves = false
-                    [difficulty]
-                    max_no_competitors = 1
-                ''' + ai_players_config)
+                ''')
             )
 
             # Run the experiment

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -39,7 +39,7 @@ def test_run_experiment_local_ai_default_version():
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
         'current_loan': 110000,
-        'money': 6546,
+        'money': 6371,
     }
     assert tuple(int(v) for v in results[58]['openttd_version'].split('.')) >= (13, 4)
     assert tuple(int(v) for v in results[58]['opengfx_version'].split('.')) >= (7, 1)
@@ -53,7 +53,7 @@ def test_run_experiment_local_ai_default_version():
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
         'current_loan': 300000,
-        'money': 672573,
+        'money': 641561,
     }
     assert tuple(int(v) for v in results[117]['openttd_version'].split('.')) >= (13, 4)
     assert tuple(int(v) for v in results[117]['opengfx_version'].split('.')) >= (7, 1)
@@ -86,7 +86,7 @@ def test_run_experiment_local_folder():
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
         'current_loan': 110000,
-        'money': 6546,
+        'money': 6371,
     }
     assert _basic_data(results[117]) == {
         'openttd_version': '13.4',
@@ -95,7 +95,7 @@ def test_run_experiment_local_folder():
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
         'current_loan': 300000,
-        'money': 672573,
+        'money': 641561,
     }
 
 
@@ -119,7 +119,7 @@ def test_run_experiment_local_file():
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
         'current_loan': 110000,
-        'money': 6546,
+        'money': 6371,
     }
     assert _basic_data(results[117]) == {
         'openttd_version': '13.4',
@@ -128,7 +128,7 @@ def test_run_experiment_local_file():
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
         'current_loan': 300000,
-        'money': 672573,
+        'money': 641561,
     }
 
 


### PR DESCRIPTION
This starts the AIs in the game immediately using a startup script, rather than waiting for them to be launched by the game engine.

Although not quite possible here yet, this is a step towards passing parameters to AIs, which would be useful when using OpenTTDLab to choose appropriate default parameters for them.

---

**BREAKING CHANGE**: Changes the results from experiments

This changes the results of OpenTTDLab because the AIs start at a different point in time than they did before. But hopefully this is a better choice - they start immediately.