### PR TITLE
feat: slightly less clunky API for AIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ results = run_experiment(
     ais=(
         # ... running specific AIs. In this case a single AI, with no
         # parameters, fetching it from https://bananas.openttd.org/package/ai
-        ('trAIns', (), bananas_file('trAIns', '54524149')),
+        bananas_file('trAIns', '54524149', ai_params=()),
     ),
 )
 ```
@@ -160,26 +160,31 @@ The core function of OpenTTDLab is the `run_experiment` function, used to run an
 
 ### Fetching AIs
 
-The `ais` parameter of `run_experiment` configures which AIs will run, and how their code will be located. Specifically, the `ais`  parameter must be an iterable of `(name, params, ai)` tuples, where `name` is the name of the AI, `params` is an iterable of `(key, value)` parameters for the AI, and `ai` must be the return value of any of the following 3 functions.
+The `ais` parameter of `run_experiment` configures which AIs will run, how their code will be located, their names, and what parameters will be passed to each of them when they start. In more detail, the `ais`  parameter must be an iterable of the return value of any of the the following 4 functions.
 
-#### `bananas_file(name, id)`
+> [!IMPORTANT]
+> The `ai_name` argument passed to each of the following functions must exactly match the name of the corresponding AI as published. If it does not match, the AI will not be started.
 
-Defines an AI by the `name` and `id` of an AI published through OpenTTD's content service at https://bananas.openttd.org/package/ai. This allows you to quickly run OpenTTDLab with a published AI.
+> [!IMPORTANT]
+> The return value of each of the following is opaque: it should not be used in client code, other than by passing into `run_experiment` as part of the `ais` parameter.
 
-#### `local_folder(path)`
+#### `bananas_file(unique_id, ai_name, ai_params=())`
 
-Defines an AI by the path to a local folder that contains the AI code.
+Defines an AI by the `unique_id` and `ai_name` of an AI published through OpenTTD's content service at https://bananas.openttd.org/package/ai. This allows you to quickly run OpenTTDLab with a published AI. The `ai_params` parameter is an optional parameter of an iterable of `(key, value)` parameters passed to the AI on startup.
 
-#### `local_file(path)`
+The `unique_id` is sometimes surfaced as the "Content Id", but it should not include its `ai/` prefix.
 
-Defines an AI by the local path to a .tar AI file that contains the AI code.
+#### `local_folder(folder_path, ai_name, ai_params=()))`
 
-#### `remote_file(url)`
+Defines an AI by the `folder_path` to a local folder that contains the AI code of an AI with name `ai_name`. The `ai_params` parameter is an optional parameter of an iterable of `(key, value)` parameters passed to the AI on startup.
 
-Fetches the AI by the URL of a tar.gz file that contains the AI code. For example, a specific GitHub tag of a repository that contains its code.
+#### `local_file(path, ai_name, ai_params=())`
 
-> [!NOTE]
-> The return value of each of the above is opaque: it should not be used in client code, other than by passing into `run_experiment` as its `ais` parameter.
+Defines an AI by the local path to a .tar AI file that contains the AI code. The `ai_params` parameter is an optional parameter of an iterable of `(key, value)` parameters passed to the AI on startup.
+
+#### `remote_file(url, ai_name, ai_params=())`
+
+Fetches the AI by the URL of a tar.gz file that contains the AI code. For example, a specific GitHub tag of a repository that contains its code. The `ai_params` parameter is an optional parameter of an iterable of `(key, value)` parameters passed to the AI on startup.
 
 
 ## Compatibility

--- a/examples/01-single-ai.ipynb
+++ b/examples/01-single-ai.ipynb
@@ -21,7 +21,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -m pip install OpenTTDLab==0.0.41 pandas==2.2.0 plotly==5.18.0"
+    "!python -m pip install OpenTTDLab==0.0.42 pandas==2.2.0 plotly==5.18.0"
    ]
   },
   {
@@ -50,7 +50,7 @@
     "    ais=(\n",
     "        # ... running specific AIs. In this case a single AI, with no\n",
     "        # parameters, fetching it from https://bananas.openttd.org/package/ai\n",
-    "        ('trAIns', (), bananas_file('trAIns', '54524149')),\n",
+    "        bananas_file('54524149', 'trAIns'),\n",
     "    ),\n",
     ")"
    ]

--- a/examples/02-openttdlab-scaling.ipynb
+++ b/examples/02-openttdlab-scaling.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install OpenTTDLab==0.0.41 pandas==2.2.0 plotly==5.18.0"
+    "!python -m pip install OpenTTDLab==0.0.42 pandas==2.2.0 plotly==5.18.0"
    ]
   },
   {
@@ -46,7 +46,7 @@
     "        days=365 * 4 + 1,\n",
     "        seeds=range(0, 32),\n",
     "        ais=(\n",
-    "            ('trAIns', (), bananas_file('trAIns', '54524149')),\n",
+    "            bananas_file('54524149', 'trAIns'),\n",
     "        ),\n",
     "        max_workers=max_workers,\n",
     "    )\n",

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -25,7 +25,7 @@ def test_run_experiment_local_ai_default_version():
         days=365 * 5 + 1,
         seeds=range(2, 4),
         ais=(
-            ('trAIns', (), local_file('./fixtures/54524149-trAIns-2.1.tar')),
+            local_file('./fixtures/54524149-trAIns-2.1.tar', 'trAIns'),
         ),
     )
 
@@ -72,7 +72,7 @@ def test_run_experiment_local_folder():
             days=365 * 5 + 1,
             seeds=range(2, 4),
             ais=(
-                ('trAIns', (), local_folder(d)),
+                local_folder(d, 'trAIns'),
             ),
             openttd_version='13.4',
             opengfx_version='7.1',
@@ -105,7 +105,7 @@ def test_run_experiment_local_file():
         days=365 * 5 + 1,
         seeds=range(2, 4),
         ais=(
-            ('trAIns', (), local_file('./fixtures/54524149-trAIns-2.1.tar')),
+            local_file('./fixtures/54524149-trAIns-2.1.tar', 'trAIns',),
         ),
         openttd_version='13.4',
         opengfx_version='7.1',
@@ -137,7 +137,7 @@ def test_run_experiment_remote():
         days=365 + 1,
         seeds=range(2, 3),
         ais=(
-            ('trAIns', (), remote_file('https://github.com/lhrios/trains/archive/refs/tags/2014_02_14.tar.gz')),
+            remote_file('https://github.com/lhrios/trains/archive/refs/tags/2014_02_14.tar.gz', 'trAIns'),
         ),
         openttd_version='13.4',
         opengfx_version='7.1',
@@ -160,7 +160,7 @@ def test_run_experiment_bananas():
         days=365 + 1,
         seeds=range(2, 3),
         ais=(
-            ('trAIns', (), bananas_file('trAIns', '54524149')),
+            bananas_file('54524149', 'trAIns'),
         ),
         openttd_version='13.4',
         opengfx_version='7.1',
@@ -188,7 +188,7 @@ def test_savegame_formats(savegame_format):
         seeds=range(2, 3),
         base_openttd_config=f'[misc]\nsavegame_format={savegame_format}\n',
         ais=(
-            ('trAIns', (), local_file('./fixtures/54524149-trAIns-2.1.tar')),
+            local_file('./fixtures/54524149-trAIns-2.1.tar', 'trAIns'),
         ),
         openttd_version='13.4',
         opengfx_version='7.1',


### PR DESCRIPTION
This makes it slightly easier to pass AIs to the API - no nested tuples, and no requirements for an empty parameter list for example.

BREAKING CHANGE: How AIs were passed to the run_experiment function has changed.

It was an iterable of tuples, but now an iterable of the return values of the 4 AI-fetcher functions.