### PR TITLE
feat: rename bananas_file to bananas_ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You do not need to separately download or install OpenTTD (or [OpenGFX](https://
 The core function of OpenTTD is the `run_experiment` function.
 
 ```python
-from openttdlab import run_experiment, bananas_file
+from openttdlab import run_experiment, bananas_ai
 
 # Run experiments...
 results = run_experiment(
@@ -72,7 +72,7 @@ results = run_experiment(
     ais=(
         # ... running specific AIs. In this case a single AI, with no
         # parameters, fetching it from https://bananas.openttd.org/package/ai
-        bananas_file('54524149', 'trAIns', ai_params=()),
+        bananas_ai('54524149', 'trAIns', ai_params=()),
     ),
 )
 ```
@@ -155,7 +155,7 @@ The core function of OpenTTDLab is the `run_experiment` function, used to run an
 
 - `get_http_client=lambda: httpx.Client(transport=httpx.HTTPTransport(retries=3)`
 
-   The HTTP client used to make HTTP requests when fetching OpenTTD, OpenGFX, or AIs. Note that the `bananas_file` function uses a raw TCP connection in addition to HTTP requests, and so not all outgoing connections use the client specified by this.
+   The HTTP client used to make HTTP requests when fetching OpenTTD, OpenGFX, or AIs. Note that the `bananas_ai` function uses a raw TCP connection in addition to HTTP requests, and so not all outgoing connections use the client specified by this.
 
 
 ### Fetching AIs
@@ -168,7 +168,7 @@ The `ais` parameter of `run_experiment` configures which AIs will run, how their
 > [!IMPORTANT]
 > The return value of each of the following is opaque: it should not be used in client code, other than by passing into `run_experiment` as part of the `ais` parameter.
 
-#### `bananas_file(unique_id, ai_name, ai_params=())`
+#### `bananas_ai(unique_id, ai_name, ai_params=())`
 
 Defines an AI by the `unique_id` and `ai_name` of an AI published through OpenTTD's content service at https://bananas.openttd.org/package/ai. This allows you to quickly run OpenTTDLab with a published AI. The `ai_params` parameter is an optional parameter of an iterable of `(key, value)` parameters passed to the AI on startup.
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -301,7 +301,7 @@ def remote_file(url, ai_name, ai_params=()):
     return ai_name, ai_params, _download
 
 
-def bananas_file(unique_id, ai_name, ai_params=()):
+def bananas_ai(unique_id, ai_name, ai_params=()):
 
     def _download(client, cache_dir, target):
         @contextlib.contextmanager

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -5,7 +5,7 @@ from datetime import date
 
 import pytest
 
-from openttdlab import parse_savegame, run_experiment, local_folder, local_file, remote_file, bananas_file
+from openttdlab import parse_savegame, run_experiment, local_folder, local_file, remote_file, bananas_ai
 
 
 def _basic_data(result_row):
@@ -160,7 +160,7 @@ def test_run_experiment_bananas():
         days=365 + 1,
         seeds=range(2, 3),
         ais=(
-            bananas_file('54524149', 'trAIns'),
+            bananas_ai('54524149', 'trAIns'),
         ),
         openttd_version='13.4',
         opengfx_version='7.1',


### PR DESCRIPTION
BREAKING CHANGE: The function bananas_file is renamed to bananas_ai

This is to make way for other bananas_* functions, and specifically thinking of bananas_ai_library to be able to use published libraries (specifically for pathfinding)