### PR TITLE
feat: option to take final screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ The core function of OpenTTDLab is the `run_experiment` function, used to run an
 
    OpenTTD config to run each experiment under. This must be in the [openttd.cfg format](https://wiki.openttd.org/en/Archive/Manual/Settings/Openttd.cfg). This is added to by OpenTTDLab before being passed to OpenTTD.
 
+- `final_screenshot_directory=None`
+
+   The directory to save a PNG screenshot of the entire map at the end of each run. Each is named in the format `<seed>.png`, where `<seed>` is the run's seed of the random number generator. If `None`, then no screenshots are saved.
+
+   For technical reasons, a window will briefly appear while each screenshot is being saved.
+
 - `max_workers=None`
  
    The maximum number of workers to use to run OpenTTD in parallel. If`None`, then `os.cpu_count()` defined how many workers run.

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -47,6 +47,7 @@ def run_experiment(
     days=365 * 4 + 1,
     seeds=(1,),
     base_openttd_config='',
+    final_screenshot_directory=None,
     max_workers=None,
     openttd_version=None,
     opengfx_version=None,
@@ -241,6 +242,28 @@ def run_experiment(
 
             autosave_dir = os.path.join(run_dir, 'save', 'autosave')
             autosave_filenames = sorted(list(os.listdir(autosave_dir)))
+
+            if final_screenshot_directory is not None:
+                with open(os.path.join(experiment_script_dir, 'game_start.scr'), 'w') as f:
+                    f.write('screenshot giant\n')
+                    f.write('quit\n')
+
+                subprocess.check_output(
+                    (openttd_binary,) + (
+                        '-g', os.path.join(autosave_dir, autosave_filenames[-1]),
+                        '-G', str(seed),          # Seed for random number generator
+                        '-snull',                 # No sound
+                        '-mnull',                 # No music
+                         '-c', config_file,       # Config file
+                    ),
+                    cwd=run_dir,                  # OpenTTD looks in the current working directory for files
+                )
+                screenshot_file = os.listdir(os.path.join(run_dir, 'screenshot'))[0]
+                shutil.copyfile(
+                    os.path.join(run_dir, 'screenshot', screenshot_file),
+                    os.path.join(final_screenshot_directory, str(seed) + '.png'),
+                )
+
             return [
                 get_savegame_row(openttd_version, opengfx_version, seed, os.path.join(autosave_dir, filename))
                 for filename in autosave_filenames


### PR DESCRIPTION
This adds the option to take a screenshot at the end of each simulation, by the `final_screenshot_directory` option to `run_experiment`.

How it works is that it loads OpenTTD again at the end of each simulation, but with the normal video driver, loading the final autosave file, takes a screenshot, and then exits. This can result in the OpenTTD window being visible for a few moments for each run, This seems unavoidable at the moment - it doesn't seem possible to take screenshots using the null video driver.