### PR TITLE
tests: disable test that uses the latest version of OpenTTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ OpenTTDLab is a Python framework for using [OpenTTD](https://github.com/OpenTTD/
 
 OpenTTDLab is based on [Patric Stout's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader).
 
+> [!CAUTION]
+> OpenTTDLab currently does not work with OpenTTD 14.0 or later. The latest version of OpenTTD known to work is 13.4.
+
 ---
 
 ### Contents
@@ -150,6 +153,9 @@ The core function of OpenTTDLab is the `run_experiment` function, used to run an
 - `openttd_version=None`
 
    The version of OpenTTD to use. If `None`, the latest version available at `openttd_base_url` is used.
+
+   > [!CAUTION]
+   > OpenTTDLab currently does not work with OpenTTD 14.0 or later. The latest version of OpenTTD known to work is 13.4.
 
 - `opengfx_version=None`
 

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -28,7 +28,10 @@ def _basic_data(result_row):
         'current_loan': result_row['chunks']['PLYR']['0']['current_loan'],
     }
 
-
+# OpenTTD 14.0 changed the way autosave works which OpenTTDLab depended on
+# It changes saving per X game time to per X real time. While this is being
+# worked on/figured out, disabling the test
+@pytest.mark.skip(reason='OpenTTDLab no longer works on OpenTTD 14.0')
 def test_run_experiment_local_ai_default_version():
     results = run_experiment(
         days=365 * 5 + 1,


### PR DESCRIPTION
OpenTTDLab won't currently work with what is now the latest version OpenTTD, OpenTTD 14.0.

Hopefully there is some way to make it work, but for now, just disabinge the test that uses the latest versions and put notes in the README.

Some related discussion at https://github.com/OpenTTD/OpenTTD/discussions/12496