### PR TITLE
feat!: rename run_experiment to run_experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ You do not need to separately download or install OpenTTD (or [OpenGFX](https://
 
 ## Running an experiment
 
-The core function of OpenTTD is the `run_experiment` function.
+The core function of OpenTTD is the `run_experiments` function.
 
 ```python
-from openttdlab import run_experiment, bananas_ai
+from openttdlab import run_experiments, bananas_ai
 
 # Run experiments...
-results = run_experiment(
+results = run_experiments(
     openttd_version='13.4',  # ... for a specific versions of OpenTTD
     opengfx_version='7.1',   # ... and a specific versions of OpenGFX
     seeds=range(0, 10),      # ... for a range of random seeds
@@ -83,7 +83,7 @@ results = run_experiment(
 
 ## Plotting results
 
-OpenTTD does not require any particular library for plotting results. However, [pandas](https://pandas.pydata.org/) and [Plotly Express](https://plotly.com/python/plotly-express/) are common options for plotting from Python. For example if you have a `results` object from `run_experiment` as in the above example, the following code
+OpenTTD does not require any particular library for plotting results. However, [pandas](https://pandas.pydata.org/) and [Plotly Express](https://plotly.com/python/plotly-express/) are common options for plotting from Python. For example if you have a `results` object from `run_experiments` as in the above example, the following code
 
 ```python
 import pandas as pd
@@ -116,9 +116,9 @@ A notebook of the above example and an example measuring the performance of Open
 
 ### Running experiments
 
-#### `run_experiment(...)`
+#### `run_experiments(...)`
 
-The core function of OpenTTDLab is the `run_experiment` function, used to run an experiment and return results extracted from the savegame files that OpenTTD produces. It has the following parameters and defaults.
+The core function of OpenTTDLab is the `run_experiments` function, used to run an experiment and return results extracted from the savegame files that OpenTTD produces. It has the following parameters and defaults.
 
 - `ais=()`
 
@@ -176,13 +176,13 @@ The core function of OpenTTDLab is the `run_experiment` function, used to run an
 
 ### Fetching AIs
 
-The `ais` parameter of `run_experiment` configures which AIs will run, how their code will be located, their names, and what parameters will be passed to each of them when they start. In more detail, the `ais`  parameter must be an iterable of the return value of any of the the following 4 functions.
+The `ais` parameter of `run_experiments` configures which AIs will run, how their code will be located, their names, and what parameters will be passed to each of them when they start. In more detail, the `ais`  parameter must be an iterable of the return value of any of the the following 4 functions.
 
 > [!IMPORTANT]
 > The `ai_name` argument passed to each of the following functions must exactly match the name of the corresponding AI as published. If it does not match, the AI will not be started.
 
 > [!IMPORTANT]
-> The return value of each of the following is opaque: it should not be used in client code, other than by passing into `run_experiment` as part of the `ais` parameter.
+> The return value of each of the following is opaque: it should not be used in client code, other than by passing into `run_experiments` as part of the `ais` parameter.
 
 #### `bananas_ai(unique_id, ai_name, ai_params=())`
 
@@ -205,7 +205,7 @@ Fetches the AI by the URL of a tar.gz file that contains the AI code. For exampl
 
 ### Fetching AI libraries
 
-The `ai_libraries` parameter of `run_experiment` ensures that AI libraries are available to the AIs running. In more detail, the `ais_libraries`  parameter must be an iterable, where each item the the return value of the following function.
+The `ai_libraries` parameter of `run_experiments` ensures that AI libraries are available to the AIs running. In more detail, the `ais_libraries`  parameter must be an iterable, where each item the the return value of the following function.
 
 #### `bananas_ai_library(unique_id, ai_library_name)`
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -43,7 +43,7 @@ from platformdirs import user_cache_dir
 __version__ = '0.0.0.dev0'
 
 
-def run_experiment(
+def run_experiments(
     ais=(),
     ai_libraries=(),
     days=365 * 4 + 1,

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -8,7 +8,7 @@ import pytest
 
 from openttdlab import (
     parse_savegame,
-    run_experiment,
+    run_experiments,
     local_folder,
     local_file,
     remote_file,
@@ -32,8 +32,8 @@ def _basic_data(result_row):
 # It changes saving per X game time to per X real time. While this is being
 # worked on/figured out, disabling the test
 @pytest.mark.skip(reason='OpenTTDLab no longer works on OpenTTD 14.0')
-def test_run_experiment_local_ai_default_version():
-    results = run_experiment(
+def test_run_experiments_local_ai_default_version():
+    results = run_experiments(
         days=365 * 5 + 1,
         seeds=range(2, 4),
         ais=(
@@ -71,7 +71,7 @@ def test_run_experiment_local_ai_default_version():
     assert tuple(int(v) for v in results[117]['opengfx_version'].split('.')) >= (7, 1)
 
 
-def test_run_experiment_local_folder():
+def test_run_experiments_local_folder():
 
     with tempfile.TemporaryDirectory() as d:
         with tarfile.open('./fixtures/54524149-trAIns-2.1.tar', 'r') as f_tar:
@@ -80,7 +80,7 @@ def test_run_experiment_local_folder():
                     raise Exception('Unsafe', archive_location)
             f_tar.extractall(d)
 
-        results = run_experiment(
+        results = run_experiments(
             days=365 * 5 + 1,
             seeds=range(2, 4),
             ais=(
@@ -111,9 +111,9 @@ def test_run_experiment_local_folder():
     }
 
 
-def test_run_experiment_local_file():
+def test_run_experiments_local_file():
 
-    results = run_experiment(
+    results = run_experiments(
         days=365 * 5 + 1,
         seeds=range(2, 4),
         ais=(
@@ -144,8 +144,8 @@ def test_run_experiment_local_file():
     }
 
 
-def test_run_experiment_remote():
-    results = run_experiment(
+def test_run_experiments_remote():
+    results = run_experiments(
         days=365 + 1,
         seeds=range(2, 3),
         ais=(
@@ -167,8 +167,8 @@ def test_run_experiment_remote():
     }
 
 
-def test_run_experiment_bananas():
-    results = run_experiment(
+def test_run_experiments_bananas():
+    results = run_experiments(
         days=365 + 1,
         seeds=range(2, 3),
         ais=(
@@ -190,8 +190,8 @@ def test_run_experiment_bananas():
     }
 
 
-def test_run_experiment_bananas_as_library():
-    results = run_experiment(
+def test_run_experiments_bananas_as_library():
+    results = run_experiments(
         days=365 + 1,
         seeds=range(2, 3),
         ais=(
@@ -218,13 +218,13 @@ def test_run_experiment_bananas_as_library():
     }
 
 
-def test_run_experiment_screenshots():
+def test_run_experiments_screenshots():
     def read_header(file):
         with open(file, 'rb') as f:
             return f.read(32)
 
     with tempfile.TemporaryDirectory(prefix=f'OpenTTD-screenshots-') as screenshot_dir:
-        results = run_experiment(
+        results = run_experiments(
             days=365 + 1,
             seeds=range(2, 4),
             ais=(
@@ -264,7 +264,7 @@ def test_run_experiment_screenshots():
     ("none", "zlib", "lzma"),
 )
 def test_savegame_formats(savegame_format):
-    results = run_experiment(
+    results = run_experiments(
         days=100,
         seeds=range(2, 3),
         base_openttd_config=f'[misc]\nsavegame_format={savegame_format}\n',


### PR DESCRIPTION
I think it seems more natural that a single "experiment" is essentially a single run of OpenTTD, and a call to this function runs a lot of them.

This I think this will work especially with a future change that will have `experiments` as a single parameters that controlls all of these experiments.

BREAKING CHANGE: This renames run_experiment to run_experiments