### PR TITLE
feat: allow OpenTTD config to be changed per experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,14 @@ The core function of OpenTTDLab is the `run_experiments` function, used to run a
 
       The integer number of in-game days that this experiment will run for.
 
+   - `openttd_config=''`
+
+      OpenTTD config to run each experiment under. This must be in the [openttd.cfg format](https://wiki.openttd.org/en/Archive/Manual/Settings/Openttd.cfg). This is added to by OpenTTDLab before being passed to OpenTTD.
+
 - `ais_libraries=()`
 
    The list of AI libraries to have available to AI code. See the [Fetching AI libraries](#fetching-ai-libraries) section for details on this parameter.
 
-- `base_openttd_config=''`
-
-   OpenTTD config to run each experiment under. This must be in the [openttd.cfg format](https://wiki.openttd.org/en/Archive/Manual/Settings/Openttd.cfg). This is added to by OpenTTDLab before being passed to OpenTTD.
 
 - `final_screenshot_directory=None`
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -45,9 +45,6 @@ __version__ = '0.0.0.dev0'
 
 def run_experiments(
     experiments=(),
-    # ais=(),
-    # seeds=(1,),
-    # days=365 * 4 + 1,
     ai_libraries=(),
     base_openttd_config='',
     final_screenshot_directory=None,

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -46,7 +46,6 @@ __version__ = '0.0.0.dev0'
 def run_experiments(
     experiments=(),
     ai_libraries=(),
-    base_openttd_config='',
     final_screenshot_directory=None,
     max_workers=None,
     openttd_version=None,
@@ -206,6 +205,7 @@ def run_experiments(
             experiment_script_dir = os.path.join(experiment_dir, 'scripts')
             Path(experiment_script_dir).mkdir(parents=True)
 
+            openttd_config = experiment.get('openttd_config', '')
             ais = experiment.get('ais', [])
             days = experiment['days']
             seed = experiment['seed']
@@ -224,7 +224,7 @@ def run_experiments(
                     for ai_name, ai_params, _ in ais
                 ))
             with open(config_file, 'w') as f:
-                f.write(base_openttd_config + textwrap.dedent('''
+                f.write(textwrap.dedent(openttd_config) + textwrap.dedent('''
                     [gui]
                     autosave = monthly
                     keep_all_autosave = true

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -159,6 +159,47 @@ def test_run_experiments_local_file():
     }
 
 
+def test_run_experiments_local_file_different_config():
+    results = run_experiments(
+        experiments=(
+            {
+                'seed': seed,
+                'ais': (
+                    local_file('./fixtures/54524149-trAIns-2.1.tar', 'trAIns',),
+                ),
+                'days': 365 * 1 + 1,
+                'openttd_config': f'[difficulty]\nterrain_type = {terrain_type}\n',
+            }
+            for seed in range(2, 3)
+            for terrain_type in [1, 3]
+        ),
+        openttd_version='13.4',
+        opengfx_version='7.1',
+    )
+
+    assert len(results) == 24
+    assert results[11]['chunks']['PATS']['0']['difficulty.terrain_type'] == 1
+    assert _basic_data(results[1]) == {
+        'openttd_version': '13.4',
+        'opengfx_version': '7.1',
+        'seed': 2,
+        'name': 'trAIns AI',
+        'date': date(1950, 3, 1),
+        'current_loan': 300000,
+        'money': 285340,
+    }
+    assert results[23]['chunks']['PATS']['0']['difficulty.terrain_type'] == 3
+    assert _basic_data(results[23]) == {
+        'openttd_version': '13.4',
+        'opengfx_version': '7.1',
+        'seed': 2,
+        'name': 'trAIns AI',
+        'date': date(1951, 1, 1),
+        'current_loan': 180000,
+        'money': 5855,
+    }
+
+
 def test_run_experiments_remote():
     results = run_experiments(
         experiments=(
@@ -300,9 +341,9 @@ def test_run_experiments_screenshots():
 )
 def test_savegame_formats(savegame_format):
     results = run_experiments(
-        base_openttd_config=f'[misc]\nsavegame_format={savegame_format}\n',
         experiments=(
             {
+                'openttd_config': f'[misc]\nsavegame_format={savegame_format}\n',
                 'seed': seed,
                 'ais': (
                     local_file('./fixtures/54524149-trAIns-2.1.tar', 'trAIns'),


### PR DESCRIPTION
This allows, for example, a single call to run_experiments to cover multiple terrain types, which are set via config

It also removes the "base" detail from the name. It was chosen to emphasise that under the hood, OpenTDDLab adds to it, but I think this detail isn't really needed to be emphasised - it adds to the load of what you have to think about somewhat needlessly.