### PR TITLE
feat: make the result processor return iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ The core function of OpenTTDLab is the `run_experiments` function, used to run a
 
    The list of AI libraries to have available to AI code. See the [Fetching AI libraries](#fetching-ai-libraries) section for details on this parameter.
 
-- `result_processor=lambda r: r`
+- `result_processor=lambda r: (r,)`
 
-   A function that takes a single result row, which is a parsed save game file from an experiment, alongside other metadata describing the experiment, and returns it processed in some way. This processed row will takes the place of the result in the return value of `run_experiments`.
+   A function that takes a single result row, which is a parsed save game file from an experiment, alongside other metadata describing the experiment, and returns it processed in some way. The function should return an iterable of zero or more rows that will appear in the the return value of `run_experiments`.
 
    This is typically used to reduce memory usage with high numbers of experiments where only a small amount of data is needed for analysis.
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -52,7 +52,7 @@ def run_experiments(
     opengfx_version=None,
     openttd_base_url='https://cdn.openttd.org/openttd-releases/',
     opengfx_base_url='https://cdn.openttd.org/opengfx-releases/',
-    result_processor=lambda x: x,
+    result_processor=lambda x: (x,),
     get_http_client=lambda: httpx.Client(transport=httpx.HTTPTransport(retries=3)),
 ):
     def get(client, url):
@@ -273,8 +273,9 @@ def run_experiments(
                 )
 
             return [
-                get_savegame_row(openttd_version, opengfx_version, experiment, os.path.join(autosave_dir, filename))
+                result_row
                 for filename in autosave_filenames
+                for result_row in get_savegame_row(openttd_version, opengfx_version, experiment, os.path.join(autosave_dir, filename))
             ]
 
         def run_done(progress, task, _):

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -18,7 +18,7 @@ from openttdlab import (
 
 
 def _basic_data(result_row):
-    return {
+    return [{
         'seed': result_row['experiment']['seed'],
         'date': result_row['date'],
         'openttd_version': result_row['openttd_version'],
@@ -27,7 +27,7 @@ def _basic_data(result_row):
         'money': result_row['chunks']['PLYR']['0']['money'],
         'current_loan': result_row['chunks']['PLYR']['0']['current_loan'],
         'terrain_type': result_row['chunks']['PATS']['0']['difficulty.terrain_type'],
-    }
+    }]
 
 # OpenTTD 14.0 changed the way autosave works which OpenTTDLab depended on
 # It changes saving per X game time to per X real time. While this is being


### PR DESCRIPTION
This changes how the result processor works - it now returns an iterable of rows that will be returned in the final results set.

This means it can return a result row per player for example, which adds a bit of flexibility and I think makes it possible to return results that are more (Hadley Wickham) tidy.