### PR TITLE
feat: automatically download dependencies from BaNaNaS

### DIFF
--- a/openttdlab.py
+++ b/openttdlab.py
@@ -28,7 +28,7 @@ import uuid
 import zipfile
 import zlib
 from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
-from collections import defaultdict
+from collections import defaultdict, deque
 from datetime import date, timedelta
 from functools import partial
 from pathlib import Path
@@ -408,13 +408,13 @@ def _bananas_download(bananas_type_id, bananas_type_str, unique_id, content_name
                     except OSError:
                         pass
 
-        def path(bananas_type_id):
+        def final_location_path(bananas_type_id):
             return {
                 CONTENT_TYPE_AI: ('ai',),
                 CONTENT_TYPE_AI_LIBRARY: ('ai', 'library',),
             }[bananas_type_id]
 
-        def get_tcp_content_id(bananas_type_id, unique_id):
+        def get_tcp_content_id(bananas_type_id, unique_id, md5sum=None):
 
             def reader(b):
                 i = 0
@@ -424,29 +424,58 @@ def _bananas_download(bananas_type_id, bananas_type_str, unique_id, content_name
                     i += num
                     return b[i-num:i]
 
-                return read_num
+                def _next_null():
+                    j = i
+                    while b[j] != 0:
+                        j += 1
+                    return j
+
+                def read_until_null():
+                    nonlocal i
+                    start = i
+                    end = _next_null()
+                    i = end + 1
+                    return b[start:end]
+
+                return read_num, read_until_null
                 
             # Convert unique ID to content ID from the Bananas TCP server, and get its expected filesize
             with tcp_connection(("content.openttd.org", 3978)) as (recv_bytes, send_bytes):
-
                 PACKET_CONTENT_CLIENT_INFO_EXTID = 2
+                PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 = 3
+                request_type = \
+                    PACKET_CONTENT_CLIENT_INFO_EXTID if md5sum is None else\
+                    PACKET_CONTENT_CLIENT_INFO_EXTID_MD5
                 packet_body = \
-                    struct.pack("<B", PACKET_CONTENT_CLIENT_INFO_EXTID) + \
+                    struct.pack("<B", request_type) + \
                     struct.pack("<B", 1) + \
                     struct.pack("<B", bananas_type_id) + \
-                    struct.pack(">I", int(unique_id, 16))
+                    struct.pack("4s", bytes.fromhex(unique_id)) + \
+                    (struct.pack("16s", bytes.fromhex(md5sum)) if md5sum is not None else b'')
                 send_bytes(struct.pack("<H", len(packet_body) + 2) + packet_body)
 
                 PACKET_CONTENT_SERVER_INFO = 4
                 packet_size = struct.unpack("<H", recv_bytes(2))[0]
                 if packet_size < 12:
                     raise Exception('Response is too small')
-                packet_read_num = reader(recv_bytes(packet_size - 2))
+                packet_read_num, packet_read_until_null = reader(recv_bytes(packet_size - 2))
                 tcp_packet_type = struct.unpack("<B", packet_read_num(1))[0]
                 tcp_content_type = struct.unpack("<B", packet_read_num(1))[0]
                 tcp_content_id = struct.unpack("<I", packet_read_num(4))[0]
+                tcp_file_size = struct.unpack("<I", packet_read_num(4))[0]
+                tcp_name = packet_read_until_null()
+                tcp_version = packet_read_until_null()
+                tcp_url = packet_read_until_null()
+                tcp_description = packet_read_until_null()
+                tcp_unique_id = packet_read_num(4)
+                tcp_md5sum = packet_read_num(16)
+                tcp_num_dependencies = packet_read_num(1)[0]
+                tcp_dependency_content_ids = [
+                    struct.unpack("<I", packet_read_num(4))[0]
+                    for _ in range(0, tcp_num_dependencies)
+                ]
 
-                return tcp_content_id
+                return tcp_content_id, tcp_dependency_content_ids
 
         # Confirm via HTTPs that this name/unique ID pair exists
         api_resp = client.get(f'https://bananas-api.openttd.org/package/{bananas_type_str}/{unique_id}')
@@ -454,20 +483,62 @@ def _bananas_download(bananas_type_id, bananas_type_str, unique_id, content_name
         api_dict = api_resp.json()
         api_dict_latest_version = max(api_dict['versions'], key=lambda version: version['version'].split('.'))
 
-        # Check if we already have this version cached
-        content_cache_dir = os.path.join(cache_dir, 'bananas', bananas_type_str)
+        # Check if we already have this version cached, and all its dependencies
+        content_cache_dir = os.path.join(cache_dir, 'bananas')
         Path(content_cache_dir).mkdir(parents=True, exist_ok=True)
         filename = f'{unique_id}-{api_dict["name"]}-{api_dict_latest_version["version"]}.tar'
         cached_file = os.path.join(content_cache_dir, filename)
-        if os.path.exists(cached_file):
+        cached_dependency_file = cached_file + '_dependencies'
+        if os.path.exists(cached_file) and os.path.exists(cached_dependency_file):
+            with open(cached_dependency_file, 'r', encoding='utf-8') as f:
+                contents = f.read()
+            dependency_filenames = [
+                (tuple(line.split(',')[0].split('/')), line.split(',')[1])
+                for line in contents.split('\n')
+            ] if contents else []
+            for path,dependency_filename in dependency_filenames:
+                shutil.copy(os.path.join(content_cache_dir, dependency_filename), os.path.join(target, dependency_filename))
+
             shutil.copy(cached_file, os.path.join(target, filename))
-            return ((path(bananas_type_id),filename),)
+            return [(final_location_path(bananas_type_id),filename),] + dependency_filenames
 
         # Check name is what client code expected
         if api_dict['name'] != content_name:
             raise Exception("Mismatched name")
 
-        tcp_content_id = get_tcp_content_id(bananas_type_id, unique_id)
+        tcp_content_id, tcp_dependency_content_ids = get_tcp_content_id(bananas_type_id, unique_id)
+
+        # Download and cache dependencies
+        dependency_filenames = []
+        dependencies_to_download = deque()
+        for tcp_dependency_content_id in tcp_dependency_content_ids:
+            dependencies_to_download.append(tcp_dependency_content_id)
+        while dependencies_to_download:
+            tcp_dependency_content_id = dependencies_to_download.popleft()
+            response = client.post('https://binaries.openttd.org/bananas', content=str(tcp_dependency_content_id).encode() + b'\n')
+            response.raise_for_status()
+            binaries_content_id, binaries_content_type, binaries_filesize, binaries_link = response.text.strip().split(',')
+            md5sum = urlparse(binaries_link).path.split('/')[3]
+            dependency_unique_id = urlparse(binaries_link).path.split('/')[2]
+            filename = urlparse(binaries_link).path.split('/')[-1][:-3]  # Withouth .gz extension
+
+            # Download from CDN URL
+            with client.stream("GET", binaries_link) as response:
+                response.raise_for_status()
+                if response.headers['content-length'] != binaries_filesize:
+                    raise Exception('Mismatched filesize')
+
+                with open(os.path.join(target, filename), 'wb') as f:
+                    for chunk in _gz_decompress(response.iter_bytes()):
+                        f.write(chunk)
+
+                dependency_cached_file = os.path.join(content_cache_dir, filename)
+                shutil.copy(os.path.join(target, filename), dependency_cached_file)
+                dependency_filenames.append((final_location_path(int(binaries_content_type)), filename),)
+
+            _, transitive_dependency_content_ids = get_tcp_content_id(int(binaries_content_type), dependency_unique_id, md5sum=md5sum)
+            for transitive_dependency_content_id in transitive_dependency_content_ids:
+                dependencies_to_download.append(transitive_dependency_content_id)
 
         # Fetch CDN URL to download from binaries server
         response = client.post('https://binaries.openttd.org/bananas', content=str(tcp_content_id).encode() + b'\n')
@@ -495,7 +566,12 @@ def _bananas_download(bananas_type_id, bananas_type_str, unique_id, content_name
                     f.write(chunk)
             shutil.copy(os.path.join(target, filename), cached_file)
 
-        return ((path(int(binaries_content_type)),filename),)
+        # Write dependency file - simple text file
+        with open(cached_dependency_file, 'w', encoding='utf-8') as f:
+            for path, dependency_filename in dependency_filenames:
+                f.write('/'.join(path) + ',' + dependency_filename)
+
+        return [(final_location_path(int(binaries_content_type)),filename),] + dependency_filenames
 
     return _download
 

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -238,7 +238,7 @@ def test_run_experiments_remote():
     }
 
 
-def test_run_experiments_bananas():
+def test_run_experiments_bananas_without_deps():
     results = run_experiments(
         experiments=(
             {
@@ -268,6 +268,36 @@ def test_run_experiments_bananas():
     }
 
 
+def test_run_experiments_bananas_with_deps():
+    results = run_experiments(
+        experiments=(
+            {
+                'seed': seed,
+                'ais': (
+                    bananas_ai('41444d4c', 'AdmiralAI'),
+                ),
+                'days': 365 + 1,
+            }
+            for seed in range(2, 3)
+        ),
+        openttd_version='13.4',
+        opengfx_version='7.1',
+        result_processor=_basic_data,
+    )
+
+    assert len(results) == 12
+    assert results[10] == {
+        'openttd_version': '13.4',
+        'opengfx_version': '7.1',
+        'seed': 2,
+        'name': 'AdmiralAI and co.',
+        'date': date(1950, 12, 1),
+        'current_loan': 300000,
+        'money': 69995,
+        'terrain_type': 1,
+    }
+
+
 def test_run_experiments_bananas_as_library():
     results = run_experiments(
         experiments=(
@@ -282,8 +312,6 @@ def test_run_experiments_bananas_as_library():
         ),
         ai_libraries=(
             bananas_ai_library('5046524f', 'Pathfinder.Road'),
-            bananas_ai_library('4752412a', 'Graph.AyStar'),
-            bananas_ai_library('51554248', 'Queue.BinaryHeap'),
         ),
         openttd_version='13.4',
         opengfx_version='7.1',


### PR DESCRIPTION
If an AI (or AI library) that is downloaded from BaNaNaS itself requires (other) AI Libraries, these are automatically downloaded, including transitive dependencies