### PR TITLE
feat: move to multiprocess from threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "dill>=0.3.8",
     "httpx>=0.26.0",
+    "multiprocess>=0.70.16",
     "platformdirs>=4.1.0",
     "PyYAML>=6.0.1",
     "rich>=13.7.1",
@@ -40,7 +42,9 @@ ci = [
   "pytest==7.4.4",
   "pytest-cov==4.1.0",
   # Pinned normal dependencies
+  "dill==0.3.8",
   "httpx==0.26.0",
+  "multiprocess==0.70.16",
   "platformdirs==4.1.0",
   "PyYAML==6.0.1",
   "rich==13.7.1",


### PR DESCRIPTION
Doing some very light nosing around `top` when experiments are running, often there are fewer openttd processing running than expected, and Python is 100%. So I suspect that Python is parsing the savegame files, and the GIL stops good scaling.

So, moving to using processes instead of threads for the parsing component.

Also, using the multiprocess module, with dill, rather than Python's built in multiprocessing, because it allows more things to be transferred to and from the process (e.g. lambda and local functions).