### PR TITLE
feat: use built-in Python multiprocessing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "dill>=0.3.8",
     "httpx>=0.26.0",
-    "multiprocess>=0.70.16",
     "platformdirs>=4.1.0",
     "PyYAML>=6.0.1",
     "rich>=13.7.1",
@@ -44,7 +43,6 @@ ci = [
   # Pinned normal dependencies
   "dill==0.3.8",
   "httpx==0.26.0",
-  "multiprocess==0.70.16",
   "platformdirs==4.1.0",
   "PyYAML==6.0.1",
   "rich==13.7.1",


### PR DESCRIPTION
Although there is a touch more awkwardness in communicating with the subprocess, pytest-cov handles code coverage in the subprocess's function. Couldn't get coverage working at all with the 3rd party multiprocess module.

For now still using "dill" to pass data back and forth since lambda functions can be passed without too much fuss.