### PR TITLE
fix: caching behaviour of libraries when there are multiple

### DIFF
--- a/openttdlab.py
+++ b/openttdlab.py
@@ -518,7 +518,7 @@ def _bananas_download(bananas_type_id, bananas_type_str, unique_id, content_name
                 contents = f.read()
             dependency_filenames = [
                 (tuple(line.split(',')[0].split('/')), line.split(',')[1])
-                for line in contents.split('\n')
+                for line in contents.splitlines()
             ] if contents else []
             for path,dependency_filename in dependency_filenames:
                 shutil.copy(os.path.join(content_cache_dir, dependency_filename), os.path.join(target, dependency_filename))
@@ -575,7 +575,7 @@ def _bananas_download(bananas_type_id, bananas_type_str, unique_id, content_name
         # Write dependency file - simple text file
         with open(cached_dependency_file, 'w', encoding='utf-8') as f:
             for path, filename in filenames[1:]:
-                f.write('/'.join(path) + ',' + filename)
+                f.write('/'.join(path) + ',' + filename + '\n')
 
         return filenames
 

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -377,37 +377,39 @@ def test_run_experiments_bananas_with_deps():
 
 
 def test_run_experiments_bananas_as_library():
-    results = run_experiments(
-        experiments=(
-            {
-                'seed': seed,
-                'ais': (
-                    local_file('./fixtures/NoOpAIImportingPathfinder-1.tar', 'NoOpAIImportingPathfinder'),
-                ),
-                'days': 365 + 1,
-            }
-            for seed in range(2, 3)
-        ),
-        ai_libraries=(
-            bananas_ai_library('5046524f', 'Pathfinder.Road'),
-        ),
-        openttd_version='13.4',
-        opengfx_version='7.1',
-        result_processor=_basic_data,
-    )
+    # Run multiple time to check caching behavior
+    for _ in range(0, 2):
+        results = run_experiments(
+            experiments=(
+                {
+                    'seed': seed,
+                    'ais': (
+                        local_file('./fixtures/NoOpAIImportingPathfinder-1.tar', 'NoOpAIImportingPathfinder'),
+                    ),
+                    'days': 365 + 1,
+                }
+                for seed in range(2, 3)
+            ),
+            ai_libraries=(
+                bananas_ai_library('5046524f', 'Pathfinder.Road'),
+            ),
+            openttd_version='13.4',
+            opengfx_version='7.1',
+            result_processor=_basic_data,
+        )
 
-    assert len(results) == 12
-    assert results[10] == {
-        'openttd_version': '13.4',
-        'opengfx_version': '7.1',
-        'seed': 2,
-        'name': 'NoOpAIImportingPathfinder',
-        'date': date(1950, 12, 1),
-        'current_loan': 100000,
-        'money': 97891,
-        'terrain_type': 1,
-        'error': False,
-    }
+        assert len(results) == 12
+        assert results[10] == {
+            'openttd_version': '13.4',
+            'opengfx_version': '7.1',
+            'seed': 2,
+            'name': 'NoOpAIImportingPathfinder',
+            'date': date(1950, 12, 1),
+            'current_loan': 100000,
+            'money': 97891,
+            'terrain_type': 1,
+            'error': False,
+        }
 
 
 def test_run_experiments_screenshots():


### PR DESCRIPTION
This fixes 'No such file or directory' errors when attempting to use AI libraries that have been already cached.

(This might need a manual clear of the cache directory if you have previously cached libraries)