### PR TITLE
feat: allow download of exact version from BaNaNaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,15 +268,15 @@ with open('my.sav') as f:
 > [!IMPORTANT]
 > Please note the license of each piece of content you download, and adhere to its rules. As examples, licenses may require you to attribute the author, they can restrict you from distributing any modifications you make, they can restrict you from using the content for commercial purposes, or they can require you to make the source available if you distribute a compiled version.
 
-#### `download_from_bananas(content_id: str)`
+#### `download_from_bananas(content_id: str, md5: Optional[str]=None)`
 
-This function is essentially a Python BaNaNaS client for downloading the latest version of content from [BaNaNaS](https://bananas.openttd.org/). Given a content id, it returns an iterable of that content and all of its direct and transitive dependencies.
+This function is a Python BaNaNaS client for downloading the content from [BaNaNaS](https://bananas.openttd.org/). Given a content id, it returns an iterable of that content and all of its direct and transitive dependencies.
 
 ```python
 from openttdlab import download_from_bananas
 
 with download_from_bananas('ai/41444d4c') as files:
-    for content_id, filename, license, md5_partial, get_data in files:
+    for content_id, filename, license, partial_or_full_md5, get_data in files:
         with get_data() as chunks:
             with open(filename, 'wb') as f:
                 for chunk in chunks:
@@ -285,7 +285,9 @@ with download_from_bananas('ai/41444d4c') as files:
 
 Each `chunks` iterable are the binary chunks of the non-compressed `.tar` file of the content. Also, under the hood `download_from_bananas` transparently caches content where possible. This is the main reason for using context managers as in the above example - they allow for robust cleanup of resources and caching of data once the data has been iterated over.
 
-Note that the function `run_experiments` that uses `bananas_ai` or `bananas_ai_library` will handle automatically downloading from BaNaNaS, so this function is usually only useful if you would like to run experiments without using the `bananas_*` functions, or report on the filename (which includes the version of each piece of content) or the (partial) MD5 sum of the file.
+If you don't pass `md5`, `download_from_bananas` will return details for the _latest_ version of the content. And if the content has a known and acceptable license, `partial_or_full_md5` will contain the full MD5 for the content, which can then be subsequently passed back into `download_from_bananas` to download the same version later. If the file does not have a known license, `download_from_bananas` will contain the only the first 8 characters of the MD5. This means that `download_from_bananas` is deterministic only for content that has an acceptable license, and if you pass an MD5 previously retrieved from a call to `download_from_bananas`.
+
+Note that the function `run_experiments` that uses `bananas_ai` or `bananas_ai_library` will handle automatically downloading from BaNaNaS, so this function is usually only useful if you would like to run experiments without using the `bananas_*` functions, or report on the filename (which includes the version of each piece of content) or the MD5 sum of the file.
 
 
 ## Compatibility

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -575,10 +575,10 @@ def test_savegame_parser():
         assert json.loads(json.dumps(game))['chunks'] == json.loads(f.read())['chunks']
 
 
-def test_bananas_download():
+def test_bananas_download_exact_version():
 
     file_details = []
-    with download_from_bananas('ai/505a4c41') as files:
+    with download_from_bananas('ai/505a4c41', md5='83b1197505bb2dcc26b14005814de75b') as files:
         for content_id, filename, license, md5sum, get_data in files:
             file_details.append((content_id, filename, license, md5sum))
             with get_data() as chunks:
@@ -587,7 +587,7 @@ def test_bananas_download():
 
     assert len(file_details) == 3
     for content_id, filename, license, md5sum in file_details:
-        assert len(md5sum) == 8
+        assert len(md5sum) == 32
     assert file_details[0][0] == 'ai/505a4c41'
     assert file_details[1][0] == 'ai-library/4752412a'
     assert file_details[2][0] == 'ai-library/51554248'
@@ -599,3 +599,36 @@ def test_bananas_download():
     assert file_details[0][2] == 'GPL v2'
     assert file_details[1][2] == 'GPL v2'
     assert file_details[2][2] == 'GPL v2'
+
+
+def test_bananas_download_latest_version_gpl():
+
+    file_details = []
+    with download_from_bananas('ai/505a4c41') as files:
+        for content_id, filename, license, md5sum, get_data in files:
+            file_details.append((content_id, filename, license, md5sum))
+            with get_data() as chunks:
+                for chunk in chunks:
+                    pass
+
+    assert len(file_details) == 3
+    for content_id, filename, license, md5sum in file_details:
+        assert len(md5sum) == 32
+    assert file_details[0][0] == 'ai/505a4c41'
+    assert file_details[1][0] == 'ai-library/4752412a'
+    assert file_details[2][0] == 'ai-library/51554248'
+
+    assert file_details[0][1].startswith('505a4c41-PathZilla')
+    assert file_details[1][1].startswith('4752412a-Graph.AyStar')
+    assert file_details[2][1].startswith('51554248-Queue.BinaryHeap')
+
+    assert file_details[0][2] == 'GPL v2'
+    assert file_details[1][2] == 'GPL v2'
+    assert file_details[2][2] == 'GPL v2'
+
+
+def test_bananas_download_latest_version_custom_license():
+
+    with download_from_bananas('ai/4349564c') as files:
+        assert files[0][2] == 'Custom'
+        assert len(files[0][3]) == 8


### PR DESCRIPTION
This change allows client code to fetch the exact version of content from BaNaNaS, if the full MD5 is supplied.

This change also now returns the full MD5 of content downloaded, but only for content that has been distributed with a license that I think allows download of the version in perpetuity. This covers virtually all current content on BaNaNaS. The only content in BaNaNaS right now where this doesn't is one with a "Custom" license.