### PR TITLE
feat!: simplify configuration of where to fetch OpenTTD binaries from

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,22 +181,18 @@ The core function of OpenTTDLab is the `run_experiments` function, used to run a
 
 - `openttd_version=None`
 
-   The version of OpenTTD to use. If `None`, the latest version available at `openttd_base_url` is used.
+   The version of OpenTTD to use. If `None`, the latest version available at `openttd_cdn_url` is used.
 
    > **Caution**
    > OpenTTDLab currently does not work with OpenTTD 14.0 or later. The latest version of OpenTTD known to work is 13.4.
 
 - `opengfx_version=None`
 
-   The version of OpenGFX to use. If `None`, the latest version available at `opengfx_base_url` is used.
+   The version of OpenGFX to use. If `None`, the latest version available at `openttd_cdn_url` is used.
 
-- `openttd_base_url='https://cdn.openttd.org/openttd-releases/`
+- `openttd_cdn_url='https://cdn.openttd.org/`
 
-   The base URL used to fetch the list of OpenTTD versions, and OpenTTD binaries.
-
-- `opengfx_base_url='https://cdn.openttd.org/opengfx-releases/`
-
-   The URL used to fetch the list of OpenGFX versions, and OpenGFX binaries.
+   The URL of the OpenTTD CDN, from which the OpenTTD and OpenGFX binaries are fetched.
 
 - `get_http_client=lambda: httpx.Client(transport=httpx.HTTPTransport(retries=3)`
 

--- a/openttdlab.py
+++ b/openttdlab.py
@@ -86,8 +86,7 @@ def run_experiments(
     max_workers=None,
     openttd_version=None,
     opengfx_version=None,
-    openttd_base_url='https://cdn.openttd.org/openttd-releases/',
-    opengfx_base_url='https://cdn.openttd.org/opengfx-releases/',
+    openttd_cdn_url='https://cdn.openttd.org/',
     result_processor=lambda x: (x,),
     get_http_client=lambda: httpx.Client(transport=httpx.HTTPTransport(retries=3)),
     get_cache_dir=lambda: user_cache_dir(appname='OpenTTDLab', version=__version__, ensure_exists=True),
@@ -176,11 +175,11 @@ def run_experiments(
 
         # Find version and coresponding manifest
         if openttd_version is None:
-            openttd_version = str(get_yaml(client, openttd_base_url + 'latest.yaml')['latest'][0]['version'])
+            openttd_version = str(get_yaml(client, openttd_cdn_url + 'openttd-releases/latest.yaml')['latest'][0]['version'])
         if opengfx_version is None:
-            opengfx_version = str(get_yaml(client, opengfx_base_url + 'latest.yaml')['latest'][0]['version'])
-        openttd_manifest = get_yaml(client, openttd_base_url + openttd_version + '/manifest.yaml')
-        opengfx_manifest = get_yaml(client, opengfx_base_url + opengfx_version + '/manifest.yaml')
+            opengfx_version = str(get_yaml(client, openttd_cdn_url + 'opengfx-releases/latest.yaml')['latest'][0]['version'])
+        openttd_manifest = get_yaml(client, openttd_cdn_url + 'openttd-releases/' + openttd_version + '/manifest.yaml')
+        opengfx_manifest = get_yaml(client, openttd_cdn_url + 'opengfx-releases/' + opengfx_version + '/manifest.yaml')
 
         # Find file details in manifest
         openttd_filename = f"{openttd_manifest['base']}{operating_system}-{architecture}.{openttd_extension}"
@@ -192,8 +191,8 @@ def run_experiments(
         cache_dir = get_cache_dir()
         openttd_archive_location = os.path.join(cache_dir, openttd_filename)
         opengfx_archive_location = os.path.join(cache_dir, opengfx_filename)
-        stream_to_file_if_necessary(client, openttd_base_url + openttd_version + '/' + openttd_filename, openttd_archive_location)
-        stream_to_file_if_necessary(client, opengfx_base_url + opengfx_version + '/' + opengfx_filename, opengfx_archive_location)
+        stream_to_file_if_necessary(client, openttd_cdn_url + 'openttd-releases/' + openttd_version + '/' + openttd_filename, openttd_archive_location)
+        stream_to_file_if_necessary(client, openttd_cdn_url + 'opengfx-releases/' + opengfx_version + '/' + opengfx_filename, opengfx_archive_location)
         check_sha_256(openttd_archive_location, openttd_file_details['sha256sum'])
         check_sha_256(opengfx_archive_location, opengfx_file_details['sha256sum'])
 


### PR DESCRIPTION
This combines openttd_base_url and opengfx_base_url into a single parameter, openttd_cdn_url, which now should not include the path/folder component.

This is a stepping stone to being able to easily use nightly versions of OpenTTD. To specify their location another parameter could have been introduced, but I'm not sure of the use case. Keeping it simple, opting to just have the one parameter that specifies the location of the OpenTTD CDN as a "just in case"/"let's keep it flexible/configurable" parameter.