### PR TITLE
refactor: use argument passed to function

### DIFF
--- a/openttdlab.py
+++ b/openttdlab.py
@@ -506,7 +506,7 @@ def download_from_bananas(
             try:
                 s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 s.settimeout(10.0)
-                s.connect(("content.openttd.org", 3978))
+                s.connect(address)
                 yield recv_bytes, send_bytes
             finally:
                 try:


### PR DESCRIPTION
It was a bit of an odd oversight to both hardocde ("content.openttd.org", 3978) twice and to pass the first instance about as though to use it. Opting to just hard code it once.