### PR TITLE
feat: support some OpenTTD and OpenGFX nightlies

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,16 +180,19 @@ The core function of OpenTTDLab is the `run_experiments` function, used to run a
  
    The maximum number of workers to use to run OpenTTD in parallel. If`None`, then `os.cpu_count()` defined how many workers run.
 
-- `openttd_version=None`
+- `openttd_version=None`<br>
+  `opengfx_version=None`
 
-   The version of OpenTTD to use. If `None`, the latest version available at `openttd_cdn_url` is used.
+   The version of OpenTTD or OpenGFX to download and use. For both of these:
+
+   - If `None`, the latest release version available at `openttd_cdn_url` is downloaded and used.
+
+   - If starting with 8 digits followed by a dash, it is assumed this is a date and so a nightly version, for example `'20230323-master-g83eb73a9b2'`.
+
+   - Otherwise a release version is assumed, for example `'13.4'`.
 
    > **Caution**
    > OpenTTDLab currently does not work with OpenTTD 14.0 or later. The latest version of OpenTTD known to work is 13.4.
-
-- `opengfx_version=None`
-
-   The version of OpenGFX to use. If `None`, the latest version available at `openttd_cdn_url` is used.
 
 - `openttd_cdn_url='https://cdn.openttd.org/`
 

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -111,6 +111,37 @@ def test_run_experiments_local_ai_early_version_of_openttd():
     }
 
 
+def test_run_experiments_local_ai_early_nightly_of_openttd():
+    results = run_experiments(
+        openttd_version='20230323-master-g83eb73a9b2',
+        opengfx_version='20230522-master-g4220c498b2',
+        experiments=(
+            {
+                'seed': seed,
+                'ais': (
+                    local_file('./fixtures/54524149-trAIns-2.1.tar', 'trAIns'),
+                ),
+                'days': 365 * 5 + 1,
+            }
+            for seed in range(2, 4)
+        ),
+        result_processor=_basic_data,
+    )
+
+    assert len(results) == 118
+    assert results[117] == {
+        'openttd_version': '20230323-master-g83eb73a9b2',
+        'opengfx_version': '20230522-master-g4220c498b2',
+        'seed': 3,
+        'name': 'trAIns AI',
+        'date': date(1954, 12, 1),
+        'current_loan': 300000,
+        'money': 1182246,
+        'terrain_type': 1,
+        'error': False,
+    }
+
+
 def test_run_experiments_local_folder_from_tar():
 
     with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
 This includes removing the sha256 of each of the binary file archives from the location of the binary files inside the "run" directory.

This is to avoid the error on Windows:

> FileNotFoundError: [WinError 206] The filename or extension is too long

The "run" directory is already a temporary directory with at least one unique ID, and we already have checked the sha256 of the file contents by this point, so having the sha256 of the binary archive in the path doesn't give anything.

Note that although this supports _some_ nightlies from a downloading and running OpenTTD point of view, the version of OpenTTD must still be compatible with OpenTTDLab in terms of extracting data, and not all version of OpenTTD are compatible.