### PR TITLE
docs: include person who converted OpenTTD logo to SVG as author

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ OpenTTDLab is licensed under the [GNU General Public License version 2.0](./LICE
 
 OpenTTDLab is based on [Patric Stout's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader), licensed under the GNU General Public License version 2.0.
 
-The [OpenTTDLab logo](./docs/assets/openttdlab-logo.svg) is a modified version of the [OpenTTD logo](https://commons.wikimedia.org/wiki/File:Openttdlogo.svg), authored by the [OpenTTD team](https://github.com/OpenTTD/OpenTTD/blob/master/CREDITS.md). The OpenTTD logo is also licensed under the GNU General Public License version 2.0.
+The [OpenTTDLab logo](./docs/assets/openttdlab-logo.svg) is a modified version of the [OpenTTD logo](https://commons.wikimedia.org/wiki/File:Openttdlogo.svg), authored by the [OpenTTD team](https://github.com/OpenTTD/OpenTTD/blob/master/CREDITS.md), converted to SVG by [User:Stannerd](https://en.wikipedia.org/wiki/User:Stannered), and then modified to become the logo for OpenTTDLab by Michal Charemza. The OpenTTD logo is also licensed under the GNU General Public License version 2.0.
 
 The [.gitignore](./.gitignore) file is based on [GitHub's Python .gitignore file](https://github.com/github/gitignore/blob/main/Python.gitignore). This was originally supplied under CC0 1.0 Universal. However, as part of OpenTTDLab it is licensed under GNU General Public License version 2.0.
 

--- a/docs/assets/openttdlab-logo.svg
+++ b/docs/assets/openttdlab-logo.svg
@@ -1,6 +1,7 @@
 <!--
 This file is part of OpenTTDLab.
 Copyright © OpenTTD Team: initial logo for OpenTTD
+Copyright © User:Stannered: conversion to SVG
 Copyright © Michal Charemza: conversion to logo for OpenTTDLab
 OpenTTDLab is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
 OpenTTDLab is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -19,7 +19,7 @@ bibliography: paper.bib
 
 OpenTTD [@openttdteam2004openttd] is a business simulation game created for recreational play, where one or more human players build commercial companies by constructing a transportation network of buses, trains, planes, and ships for use in moving passengers and cargo. OpenTTD can be extended by allowing autonomous so-called AI players written using the Squirrel programming language, and OpenTTDLab leverages this capability to allow researchers to run experiments using their own AIs. Doing so converts OpenTTD from a game into a system for researching algorithms and their effects on companies and supply chains, and helps to ensure the results of such research are reproducible.
 
-![The OpenTTDLab logo. Adapted from the OpenTTD Logo, © OpenTTD Team, licenced under the GNU General Public License Version 2.](../docs/assets/openttdlab-logo.svg){height="100pt"}
+![The OpenTTDLab logo. Adapted from the OpenTTD Logo, © [OpenTTD Team](https://github.com/OpenTTD/OpenTTD/blob/master/CREDITS.md), [User:Stannerd](https://en.wikipedia.org/wiki/User:Stannered), and Michal Charemza. Licenced under the GNU General Public License Version 2.](../docs/assets/openttdlab-logo.svg){height="100pt"}
 
 # Statement of need
 


### PR DESCRIPTION
Have to admit I'm not 100% if such a conversion adds to the people who own copyright.