### PR TITLE
feat: support OpenTTD 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OpenTTDLab is a Python framework for using [OpenTTD](https://github.com/OpenTTD/
 OpenTTDLab is based on [Patric Stout's OpenTTD Savegame Reader](https://github.com/TrueBrain/OpenTTD-savegame-reader).
 
 > [!CAUTION]
-> OpenTTDLab currently does not work with OpenTTD 14.0 or later. The latest version of OpenTTD known to work is 13.4.
+> OpenTTDLab does not support running experiments using OpenTTD 14.\* - see [Compatibility](#compatibility) for more details.
 
 ---
 
@@ -349,7 +349,7 @@ This is arguably the most difficult of the 3Rs to plan for, and for other resear
 
 ## Compatibility
 
-- OpenTTD versions between 12.0 and 13.4 (OpenTTD >= 14.0 is not currently supported. See this [discussion on the changes in OpenTTD 14.0](https://github.com/OpenTTD/OpenTTD/discussions/12496).)
+- OpenTTD versions 12.\*, 13.\*, and 15.\* and (presumably) later are supported. OpenTTD 14.\* is not supported; see this [discussion on the changes in OpenTTD 14.0](https://github.com/OpenTTD/OpenTTD/discussions/12496).
 - Linux (tested on Ubuntu 20.04), Windows (tested on Windows Server 2019), or macOS (tested on macOS 13)
 - Python >= 3.8.0 (tested on 3.8.0 and 3.12.0)
 

--- a/test_openttdlab.py
+++ b/test_openttdlab.py
@@ -31,12 +31,11 @@ def _basic_data(result_row):
         'error': result_row['error'],
     }]
 
-# OpenTTD 14.0 changed the way autosave works which OpenTTDLab depended on
-# It changes saving per X game time to per X real time. While this is being
-# worked on/figured out, disabling the test
-@pytest.mark.skip(reason='OpenTTDLab no longer works on OpenTTD 14.0')
-def test_run_experiments_local_ai_default_version():
+
+def test_run_experiments_local_ai_openttd_15_0_beta_1():
     results = run_experiments(
+        openttd_version='15.0-beta1',
+        opengfx_version='7.1',
         experiments=(
             {
                 'seed': seed,
@@ -47,37 +46,47 @@ def test_run_experiments_local_ai_default_version():
             }
             for seed in range(2, 4)
         ),
+        result_processor=_basic_data,
     )
 
-    assert len(results) == 118
-    assert {
-        key: value
-        for key, value in _basic_data(results[58]).items()
-        if key not in ('openttd_version', 'opengfx_version')
-    } == {
+    assert len(results) == 122
+
+    assert results[0] == {
+        'seed': 2,
+        # AIs typically name themselves just after start, so I think "correct" it has no name
+        'name': '',
+        'date': date(1950, 1, 1),
+        'current_loan': 100000,
+        'money': 100000,
+        'error': False,
+        'opengfx_version': '7.1',
+        'openttd_version': '15.0-beta1',
+        'terrain_type': 1,
+    }
+
+    assert results[59] == {
         'seed': 2,
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
-        'current_loan': 110000,
-        'money': 6371,
-        'error': '',
+        'current_loan': 300000,
+        'money': 532074,
+        'error': False,
+        'opengfx_version': '7.1',
+        'openttd_version': '15.0-beta1',
+        'terrain_type': 1,
     }
-    assert tuple(int(v) for v in results[58]['openttd_version'].split('.')) >= (13, 4)
-    assert tuple(int(v) for v in results[58]['opengfx_version'].split('.')) >= (7, 1)
 
-    assert {
-        key: value
-        for key, value in _basic_data(results[117]).items()
-        if key not in ('openttd_version', 'opengfx_version')
-    } == {
+    assert results[120] == {
         'seed': 3,
         'name': 'trAIns AI',
         'date': date(1954, 12, 1),
-        'current_loan': 300000,
-        'money': 641561,
+        'current_loan': 0,
+        'money': 1298270,
+        'error': False,
+        'opengfx_version': '7.1',
+        'openttd_version': '15.0-beta1',
+        'terrain_type': 1,
     }
-    assert tuple(int(v) for v in results[117]['openttd_version'].split('.')) >= (13, 4)
-    assert tuple(int(v) for v in results[117]['opengfx_version'].split('.')) >= (7, 1)
 
 
 def test_run_experiments_local_ai_early_version_of_openttd():


### PR DESCRIPTION
This fixes https://github.com/michalc/OpenTTDLab/issues/234 by using the "schedule" console script command, added in https://github.com/OpenTTD/OpenTTD/pull/12761 and released in OpenTTD 15, to emulate the pre OpenTTD 14 in-game-time autosave behaviour.

This also adds in a savegame just after the AI creation, which I think is probably a good thing in terms of charting results