### PR TITLE
docs: ensure no 'The' when referring to the Unversity of Edinburgh in a citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,4 +18,4 @@ preferred-citation:
   year: 2024
   month: 11
   title: "A Reusable Python Framework for Repeatable, Replicable, & Reproducible Experiments Using OpenTTD"
-  notes: "Master's dissertation, The University of Edinburgh, UK"
+  notes: "Master's dissertation, University of Edinburgh, UK"

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Following is a suggested BibTeX-style entry; feel free to modify it for your nee
     type         = {Master's dissertation},
     month        = {11},
     year         = {2024},
-    school       = {The University of Edinburgh},
+    school       = {University of Edinburgh},
     address      = {UK},
     doi          = {10.7488/era/5414},
     url          = {https://doi.org/10.7488/era/5414}


### PR DESCRIPTION
Hard to know the right thing, but

- https://ror.org/01nrxwf90 does not include 'The' in the institution name (but it does for other institution names)
- https://www.wikidata.org/wiki/Q160302 has 'The University of Edinburgh' only in the "Also known as" section
- https://api.crossref.org/funders/501100000848 also 'The University of Edinburgh' only in the 'alt-names' section

What this is _not_ consistent with is that https://www.ed.ac.uk/ seemingly everywhere uses 'The/the University of Edinburgh'.