### PR TITLE
feat: drop support for Python 3.8.0 and 3.8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.8.0"
-            os: "ubuntu-20.04"
+          - python-version: "3.8.2"
+            os: "ubuntu-24.04"
           - python-version: "3.12.0"
-            os: "ubuntu-20.04"
-          - python-version: "3.8.0"
+            os: "ubuntu-24.04"
+          - python-version: "3.8.2"
             os: "macos-13"
           - python-version: "3.12.0"
             os: "macos-13"
-          - python-version: "3.8.0"
+          - python-version: "3.8.2"
             os: "windows-2019"
           - python-version: "3.12.0"
             os: "windows-2019"
@@ -28,12 +28,16 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '${{ matrix.python-version }}'
+          # Pin to be able to install older Python
+          version: "0.6.17"
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
       - name: "Install python dependencies"
         run: |
-          pip install ".[ci]"
+          uv pip install ".[ci]"
       - name: "Run tests"
         run: |
           pytest --cov

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ This is arguably the most difficult of the 3Rs to plan for, and for other resear
 
 - OpenTTD versions 12.\*, 13.\*, 15.\* and (presumably) later are supported. OpenTTD 14.\* is not supported; see this [discussion on the changes in OpenTTD 14.0](https://github.com/OpenTTD/OpenTTD/discussions/12496).
 - Linux (tested on Ubuntu 20.04), Windows (tested on Windows Server 2019), or macOS (tested on macOS 13)
-- Python >= 3.8.0 (tested on 3.8.0 and 3.12.0)
+- Python >= 3.8.2 (tested on 3.8.2 and 3.12.0)
 
 
 ## How to report an issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Python framework for running reproducible experiments using OpenTTD"
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.8.2"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",


### PR DESCRIPTION
 The previous version of Ubuntu has been retired from GitHub actions, and the more recent versions don't have support for older Python. To run older Python, it seems the easiest way is to install it with uv. But uv also doesn't seem to support Python 3.8.0 and Python 3.8.1. Suspect it's not worth putting too much effort into supporting these two specific versions, so dropping support for them.